### PR TITLE
chore: update metadata format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
 FROM python:3.7.4-stretch
 
-LABEL "com.github.actions.name"="poetry - Python"
-LABEL "com.github.actions.description"="GitHub Actions for Python projects using poetry"
-LABEL "com.github.actions.icon"="package"
-LABEL "com.github.actions.color"="blue"
-
-LABEL "repository"="https://github.com/abatilo/actions-poetry"
-LABEL "homepage"="https://github.com/abatilo/actions-poetry"
-LABEL "maintainer"="abatilo"
-
 RUN pip install poetry==0.12.17
-COPY entrypoint.sh /
 
+COPY entrypoint.sh /
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,9 @@
+name: 'Python Poetry Action'
+author: '@abatilo'
+description: 'An action to run https://github.com/sdispater/poetry'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'truck'
+  color: 'gray-dark'


### PR DESCRIPTION
We were previously using the original Actions v1 metadata setup. This
updates the metadata to be displayed in the GitHub Marketplace