### PR TITLE
chore: add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "feat"
+      include_scope: true
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"


### PR DESCRIPTION
Dependabot will update the version of Python used in the Dockerfile
automatically. This means we should always have the most up to date
version of Python available with this action.