### PR TITLE
feat: Support under specified versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        python_version: [3.5.9, 3.7.0, 3.8.0]
+        python_version: [3.5, 3.6, 3.7, 3.8]
         poetry_version: [0.12.17]
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,8 @@ RUN apt-get update \
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT && \
     rm -rfv $PYENV_ROOT/.git
 
+# Install xxenv-latest, for inferring latest version of python
+RUN git clone https://github.com/momo-lab/xxenv-latest.git $PYENV_ROOT/plugins/xxenv-latest
+
 COPY requirements.txt entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   python_version:
     description: 'The version of python to install'
     required: true
-    default: '3.8.0'
+    default: '3.8'
   poetry_version:
     description: 'The version of poetry to install'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+set -e
 pythonVersion="$INPUT_PYTHON_VERSION"
 poetryVersion="$INPUT_POETRY_VERSION"
-pyenv install $pythonVersion
-pyenv global $pythonVersion
+pyenv latest install $pythonVersion
+pyenv latest global $pythonVersion
 pip install -r /requirements.txt
 pip install poetry==$poetryVersion
 pyenv rehash


### PR DESCRIPTION
This change allows you to under specify a version of Python, such as
dropping the patch version number, and the action will still work. This
works even if you drop the minor version number and the patch version
number.

We're using the https://github.com/momo-lab/xxenv-latest plugin to find
the latest version of Python based on whatever version you gave it.

Fixes #12