### PR TITLE
feat: Adds working_directory Input to Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         python_version: ${{ matrix.python_version }}
         poetry_version: ${{ matrix.poetry_version }}
+        working_directory: '.'
   release:
     needs: ci
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ jobs:
       with:
         python_version: 3.8.0
         poetry_version: 0.12.17
+        working_directory: ./working_dir # Optional, defaults to '.'
         args: install
     - name: Run pytest
       uses: abatilo/actions-poetry@v1.1.0
       with:
         python_version: 3.8.0
         poetry_version: 0.12.17
+        working_directory: ./working_dir
         args: run python -m pytest --cov=src --cov-branch --cov-fail-under=100 tests/
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -16,3 +16,6 @@ inputs:
     description: 'The version of poetry to install'
     required: true
     default: '0.12.17'
+  working_directory:
+    description: 'The directory to run poetry commands in.'
+    required: false

--- a/action.yml
+++ b/action.yml
@@ -19,3 +19,4 @@ inputs:
   working_directory:
     description: 'The directory to run poetry commands in.'
     required: false
+    default: '.'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,9 @@ if [ -n "$INPUT_WORKING_DIRECTORY" ]; then
   echo -e "Changing to working directory $INPUT_WORKING_DIRECTORY..."
 fi
 
+# Fix for virtualenvs defined in .python-version.
+pyenv local "$INPUT_PYTHON_VERSION"
+
 sh -c "poetry $*"
 
 # Step back to starting directory.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 set -e
-pythonVersion="$INPUT_PYTHON_VERSION"
-poetryVersion="$INPUT_POETRY_VERSION"
-pyenv latest install $pythonVersion
-pyenv latest global $pythonVersion
+pyenv latest install "$INPUT_PYTHON_VERSION"
+pyenv latest global "$INPUT_PYTHON_VERSION"
 pip install -r /requirements.txt
-pip install poetry==$poetryVersion
+pip install poetry=="$INPUT_POETRY_VERSION"
 pyenv rehash
 
+# If INPUT_DIRECTORY variable is defined, try to CD into it.
+if [ -z "$INPUT_WORKING_DIRECTORY" ]; then
+  pushd . > /dev/null 2>&1 || return
+  cd "$INPUT_DIRECTORY" || return
+fi
+
 sh -c "poetry $*"
+
+# Step back to starting directory.
+if [ -z "$INPUT_WORKING_DIRECTORY" ]; then
+  popd > /dev/null 2>&1 || return
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,13 +6,9 @@ pip install -r /requirements.txt
 pip install poetry=="$INPUT_POETRY_VERSION"
 pyenv rehash
 
-# If INPUT_DIRECTORY variable is defined, try to CD into it.
-if [ -n "$INPUT_WORKING_DIRECTORY" ]; then
-  pushd . > /dev/null 2>&1 || return
-  cd "$INPUT_WORKING_DIRECTORY" || return
-
-  echo -e "Changing to working directory $INPUT_WORKING_DIRECTORY..."
-fi
+# Push current directory on to stack and cd (if possible) into working dir.
+pushd . > /dev/null 2>&1 || return
+cd "$INPUT_WORKING_DIRECTORY" || return
 
 # Fix for virtualenvs defined in .python-version.
 pyenv local "$INPUT_PYTHON_VERSION"
@@ -20,6 +16,4 @@ pyenv local "$INPUT_PYTHON_VERSION"
 sh -c "poetry $*"
 
 # Step back to starting directory.
-if [ -n "$INPUT_WORKING_DIRECTORY" ]; then
-  popd > /dev/null 2>&1 || return
-fi
+popd > /dev/null 2>&1 || return

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,9 @@ pyenv rehash
 # If INPUT_DIRECTORY variable is defined, try to CD into it.
 if [ -z "$INPUT_WORKING_DIRECTORY" ]; then
   pushd . > /dev/null 2>&1 || return
-  cd "$INPUT_DIRECTORY" || return
+  cd "$INPUT_WORKING_DIRECTORY" || return
+
+  echo -e "Changing to working directory $INPUT_WORKING_DIRECTORY..."
 fi
 
 sh -c "poetry $*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ pip install poetry=="$INPUT_POETRY_VERSION"
 pyenv rehash
 
 # If INPUT_DIRECTORY variable is defined, try to CD into it.
-if [ -z "$INPUT_WORKING_DIRECTORY" ]; then
+if [ -n "$INPUT_WORKING_DIRECTORY" ]; then
   pushd . > /dev/null 2>&1 || return
   cd "$INPUT_WORKING_DIRECTORY" || return
 
@@ -17,6 +17,6 @@ fi
 sh -c "poetry $*"
 
 # Step back to starting directory.
-if [ -z "$INPUT_WORKING_DIRECTORY" ]; then
+if [ -n "$INPUT_WORKING_DIRECTORY" ]; then
   popd > /dev/null 2>&1 || return
 fi


### PR DESCRIPTION
This PR contains a change that allows the user of the action to specify a working directory where their project is located. Currently, this action assumes that the `pyproject.toml` is located in the root of the repository, which isn't always the case.

Other minor changes include changing the entrypoint shell from `sh` to `bash` and some shell style fixes (as indicated by [shellcheck](https://github.com/koalaman/shellcheck)).