### PR TITLE
fix: use a more recent version of pip

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ cd "$INPUT_WORKING_DIRECTORY" || return
 # Fix for virtualenvs defined in .python-version.
 pyenv latest local "$INPUT_PYTHON_VERSION"
 
+sh -c "poetry pip install --upgrade pip"
 sh -c "poetry $*"
 
 # Step back to starting directory.


### PR DESCRIPTION
Otherwise, poetry's pip will default to a much older version described in the docker file