### PR TITLE
fix: remove pycache to aviod further permission error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,5 +15,8 @@ pyenv latest local "$INPUT_PYTHON_VERSION"
 
 sh -c "poetry $*"
 
+# Clean up __pycache__
+find . -type d -name  "__pycache__" -exec rm -r {} +
+
 # Step back to starting directory.
 popd > /dev/null 2>&1 || return


### PR DESCRIPTION
The `__pycache__` files generated during `docker build` would be a `root:root` permission which will make the further build error in the host. I have this issue both in the `self hosted` env and the default github `ubuntu` container. 