### PR TITLE
feat: Update default poetry version to 1.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        poetry-version: [1.0, 1.0.10]
+        poetry-version: [1.0, 1.1.2]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        poetry-version: [1.0, 1.0.10]
+        poetry-version: [1.0, 1.1.2]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   poetry-version:
     description: "The version of poetry to install"
     required: true
-    default: "1.0"
+    default: "1.1.2"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Version 1.1.2 [was released a week ago](https://github.com/python-poetry/poetry/releases), should this action use the latest by default?