### PR TITLE
feat: Speed up installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        poetry-version: [1.0.0, 1.1.2]
+        poetry-version: [1.1.3]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
         poetry-version: [1.0, 1.1.2]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/cache@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-poetry
       - name: Run image
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        poetry-version: [1.0, 1.1.2]
+        poetry-version: [1.0.0, 1.1.2]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -40,19 +40,9 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-poetry
       - name: Run image
-        uses: ./
+        uses: abatilo/actions-poetry@v2.1.0
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: View poetry --help
         run: poetry --help
 ```
-
-## License
-
-[MIT License - abatilo/actions-poetry]
-
-[mit license - abatilo/actions-poetry]: https://github.com/abatilo/actions-poetry/blob/master/LICENSE
-
-## About the author
-
-- [abatilo's homepage](https://www.aaronbatilo.dev/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # actions-poetry
+
 GitHub Actions for Python projects using poetry
 
 [![license](https://img.shields.io/github/license/abatilo/actions-poetry.svg)](https://github.com/abatilo/actions-poetry/blob/master/LICENSE)
@@ -10,12 +11,16 @@ GitHub Actions for Python projects using poetry
 ## Getting started
 
 ### Breaking changes for v2
+
 We've drastically simplified this GitHub Action for v2. This is no longer a
 Docker action that runs as its own container, it's just a simplified way for
-you to install poetry. This action now makes an assumption that you've already
-setup Python via `setup-python` or some other way. Since we're installing poetry directly to your environment, this also means that you can cache your dependencies more easily since everything is running on the host runner instead of an isolated container environment.
+you to install poetry. Since we're installing poetry directly to your
+environment, this also means that you can cache your dependencies more easily
+since everything is running on the host runner instead of an isolated container
+environment.
 
 ### Create your workflow
+
 ```yaml
 name: CI
 on: pull_request
@@ -25,17 +30,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
         poetry-version: [1.0, 1.1.2]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/cache@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-poetry
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: ./
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: View poetry --help
@@ -46,8 +51,7 @@ jobs:
 
 [MIT License - abatilo/actions-poetry]
 
-[MIT License - abatilo/actions-poetry]: https://github.com/abatilo/actions-poetry/blob/master/LICENSE
-
+[mit license - abatilo/actions-poetry]: https://github.com/abatilo/actions-poetry/blob/master/LICENSE
 
 ## About the author
 

--- a/action.yml
+++ b/action.yml
@@ -14,4 +14,5 @@ runs:
   steps:
     - run: |
         curl -sSl -vvv https://raw.githubusercontent.com/python-poetry/poetry/${{ inputs.poetry-version }}/get-poetry.py | python -
+        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   poetry-version:
     description: "The version of poetry to install"
     required: true
-    default: "1.1.2"
+    default: "1.1.3"
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ runs:
   using: "composite"
   steps:
     - run: |
-        pip install poetry==${{ inputs.poetry-version }}
+        curl -sSl https://raw.githubusercontent.com/python-poetry/poetry/${{ inputs.poetry-version }}/get-poetry.py | python -
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ runs:
   using: "composite"
   steps:
     - run: |
-        curl -sSl https://raw.githubusercontent.com/python-poetry/poetry/${{ inputs.poetry-version }}/get-poetry.py | python -
+        curl -sSl -vvv https://raw.githubusercontent.com/python-poetry/poetry/${{ inputs.poetry-version }}/get-poetry.py | python -
       shell: bash


### PR DESCRIPTION
By using the direct `curl` installation method, we don't have to worry
about having `pip` installed. The `curl` installation method downloads
to `~/.poetry` which means that future runs can have the download
cached.

Closes #36 