### PR TITLE
fix: quote versions to fix parsing errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         poetry-version: [1.0, 1.1.11]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        poetry-version: [1.0, 1.1.11]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        poetry-version: ["1.0", "1.1.11"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Previously, the python version 3.10 was parsed as a 3.1 because the number 3.10 is the same as 3.1.

Quoting it as a string fixes the parsing, where it correctly reads it as "3.10"

Additionally, introduced python versions 3.9 and 3.10.

Relates to #46 