### PR TITLE
fix: Updating default poetry version to 1.15

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   poetry-version:
     description: "The version of poetry to install"
     required: true
-    default: "1.1.11"
+    default: "1.1.15"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
https://github.com/python-poetry/poetry/releases/tag/1.1.15 is released