### PR TITLE
docs: Use major version for version expression in the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: View poetry --help


### PR DESCRIPTION
Thank you very much for responding to my request in #51.
This is a small follow-up to recommend users to use the major version tag.