### PR TITLE
ci: Upgrade to ubuntu-20.04 from ubuntu-18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         poetry-version: [1.0, 1.1.15, 1.2.2]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 18.04 is being deprecated in 3 months.

https://github.com/actions/runner-images/issues/6002