### PR TITLE
feat: by default use the latest poetry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        poetry-version: ["1.0", "1.1.15", "1.2.2", "1.3.1"]
+        poetry-version: ["latest", "1.0", "1.1.15", "1.2.2", "1.3.1"]
         os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   poetry-version:
     description: "The version of poetry to install"
-    required: true
+    required: false
     default: "latest"
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - if: ${{ inputs.poetry-version == 'latest' }}
+      run: |
         pip install -U poetry
-      if: ${{ inputs.poetry-version == 'latest' }}
       shell: bash
-    - run: |
+    - if: ${{ inputs.poetry-version != 'latest' }}
+      run: |
         pip install poetry==${{ inputs.poetry-version }}
-      if: ${{ inputs.poetry-version != 'latest' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,15 @@ inputs:
   poetry-version:
     description: "The version of poetry to install"
     required: true
-    default: "1.2.2"
+    default: "latest"
 runs:
   using: "composite"
   steps:
     - run: |
+        pip install -U poetry
+      if: ${{ inputs.poetry-version == 'latest' }}
+      shell: bash
+    - run: |
         pip install poetry==${{ inputs.poetry-version }}
+      if: ${{ inputs.poetry-version != 'latest' }}
       shell: bash


### PR DESCRIPTION
Hello,

with this PR the input variable `poetry-version` is no longer a required parameter.

By default the latest version of Poetry will be installed. If a user requires a specific version, it still can be specified with the `poetry-version` variable like before.