### PR TITLE
feat!: use pipx to isolate poetry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
-        pipx install --pip-args="-U" poetry
+        pipx install poetry
       shell: bash
     - if: ${{ inputs.poetry-version != 'latest' }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
-        pipx install -U poetry
+        pipx install --pip-args="-U" poetry
       shell: bash
     - if: ${{ inputs.poetry-version != 'latest' }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - run: |
+        pip install --user pipx
+        pipx ensurepath
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
-        pip install -U poetry
+        pipx install -U poetry
       shell: bash
     - if: ${{ inputs.poetry-version != 'latest' }}
       run: |
-        pip install poetry==${{ inputs.poetry-version }}
+        pipx install poetry==${{ inputs.poetry-version }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ runs:
     - run: |
         pip install --user pipx
         pipx ensurepath
+      shell: bash
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
         pipx install -U poetry

--- a/action.yml
+++ b/action.yml
@@ -24,3 +24,4 @@ runs:
       run: |
         pipx install poetry==${{ inputs.poetry-version }}
       shell: bash
+


### PR DESCRIPTION
Following poetry recommendation, it better to use pipx instead of pip to avoid mixing application dependencies with poetry's 
https://python-poetry.org/docs/#ci-recommendations

BREAKING CHANGE: Switch using an isolated pipx virtualenv