### PR TITLE
feat: Add ability to install plugins as part of the action setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        poetry-version: ["latest", "1.0", "1.1.15", "1.2.2", "1.3.1"]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        poetry-version: ["latest", "1.2.2", "1.3.2", "1.4.2", "1.5.1", "1.6.1"]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run image

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -10,6 +10,6 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        poetry-version: ["1.0", "1.1.15"]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        poetry-version: ["1.2.2", "1.7.1"]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -80,7 +80,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Python
         uses: actions/setup-python@v4
         # see details (matrix, python-version, python-version-file, etc.)

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   poetry-plugins:
     description: "The whitespace/newline-separated list of poetry plugins to install."
     required: false
-    default: "poetry-plugin-export"
+    default: ""
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,8 @@ runs:
       run: |
         pip install poetry==${{ inputs.poetry-version }}
       shell: bash
-    - run: |
+    - if: ${{ inputs.poetry-plugins != '' }}
+      run: |
         ALL_PLUGINS=$(echo "${{ inputs.poetry-plugins }}")
         for PLUGIN in $ALL_PLUGINS; do
           poetry self add $PLUGIN

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "The version of poetry to install"
     required: false
     default: "latest"
+  poetry-plugins:
+    description: "The whitespace/newline-separated list of poetry plugins to install."
+    required: false
+    default: "poetry-plugin-export"
 runs:
   using: "composite"
   steps:
@@ -19,4 +23,10 @@ runs:
     - if: ${{ inputs.poetry-version != 'latest' }}
       run: |
         pip install poetry==${{ inputs.poetry-version }}
+      shell: bash
+    - run: |
+        ALL_PLUGINS=$(echo "${{ inputs.poetry-plugins }}")
+        for PLUGIN in $ALL_PLUGINS; do
+          poetry self add $PLUGIN
+        done
       shell: bash


### PR DESCRIPTION
So starting somewhat time soon Poetry will not install plugins (such as export plugin e.g.) by default. So this PR add ability to install plugins by default and also installs the export plugin for you by default.

As part of the PR I have also updated versions of the GH actions used in workflows.