### PR TITLE
ci: Create catch-all GHA job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,15 @@ jobs:
           poetry-version: ${{ matrix.poetry-version }}
       - name: View poetry --help
         run: poetry --help
+  ci-all:
+    runs-on: ubuntu-latest
+    needs: [ci]
+    steps:
+      - run: |
+          echo "All matrix jobs have completed successfully!"
   release:
     if: github.event_name == 'push'
-    needs: ci
+    needs: ci-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This will make it so that I can make the success of ci-all be the
required step for branch protection rules. That way, if the combination
of versions of Python and OS change, then I don't have to change the
branch protection rules themselves.
