### PR TITLE
fix: ubuntu pipx installation by calling pip from python3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ runs:
   using: "composite"
   steps:
     - run: |
-        pip install --user pipx
-        pipx ensurepath
+        python3 -m pip install --user pipx
+        python3 -m pipx ensurepath
       shell: bash
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |


### PR DESCRIPTION
Fixes #68 by explicitly calling `python3 -m pip install`

Signed-off-by: Tiago Reis <tiagovrtreis@gmail.com>