### PR TITLE
feat: Support latest main branch commit for poetry-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        poetry-version: ["latest", "1.2.2", "1.3.2", "1.4.2", "1.5.1", "1.6.1"]
+        poetry-version: ["latest", "main", "1.2.2", "1.3.2", "1.4.2", "1.5.1", "1.6.1"]
         os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,11 @@ runs:
       run: |
         pipx install poetry
       shell: bash
-    - if: ${{ inputs.poetry-version != 'latest' }}
+    - if: ${{ inputs.poetry-version == 'main' }}
+      run: |
+        pipx install git+https://github.com/python-poetry/poetry.git@main
+      shell: bash
+    - if: ${{ inputs.poetry-version != 'latest' && inputs.poetry-version != 'main' }}
       run: |
         pipx install poetry==${{ inputs.poetry-version }}
       shell: bash


### PR DESCRIPTION
Related to #74

Add support for installing the latest `main` branch commit of Poetry.

* **action.yml**
  - Add a new condition to check if `poetry-version` is "main".
  - Add a new step to install the latest `main` branch commit of Poetry if `poetry-version` is "main".
  - Update the condition for installing specific versions of Poetry to exclude "main".

* **.github/workflows/ci.yml**
  - Add "main" to the `poetry-version` matrix.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abatilo/actions-poetry/issues/74?shareId=2232111d-c069-4cf5-b846-f192c9c69571).