### PR TITLE
ci: Only auto update v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag -d v2
-          git push --delete origin v2
-          git push origin :refs/tags/v2
-          git tag v2
+          git tag -d v3
+          git push --delete origin v3
+          git push origin :refs/tags/v3
+          git tag v3
           git push --tags


### PR DESCRIPTION
We had a breaking change and I should have stopped updating v2 as a
moving tag.

This was highlighted by @mmontesi in https://github.com/abatilo/actions-poetry/issues/76#issuecomment-2442182667
