### PR TITLE
fix!: pipx is pre-installed in GitHub Actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        python3 -m pip install --user pipx
-        python3 -m pipx ensurepath
-      shell: bash
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
         pipx install poetry


### PR DESCRIPTION
https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages
https://github.com/actions/runner-images/blob/main/README.md#package-managers-usage