### PR TITLE
fix: pipx install poetry --python $(which python)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,15 +18,15 @@ runs:
   steps:
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
-        pipx install poetry --python $(which python)
+        pipx install poetry --python $(which python3)
       shell: bash
     - if: ${{ inputs.poetry-version == 'main' }}
       run: |
-        pipx install git+https://github.com/python-poetry/poetry.git@main --python $(which python)
+        pipx install git+https://github.com/python-poetry/poetry.git@main --python $(which python3)
       shell: bash
     - if: ${{ inputs.poetry-version != 'latest' && inputs.poetry-version != 'main' }}
       run: |
-        pipx install poetry==${{ inputs.poetry-version }} --python $(which python)
+        pipx install poetry==${{ inputs.poetry-version }} --python $(which python3)
       shell: bash
     - if: ${{ inputs.poetry-plugins != '' }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -18,18 +18,15 @@ runs:
   steps:
     - if: ${{ inputs.poetry-version == 'latest' }}
       run: |
-        pipx install poetry
+        pipx install poetry --python $(which python)
       shell: bash
     - if: ${{ inputs.poetry-version == 'main' }}
       run: |
-        pipx install git+https://github.com/python-poetry/poetry.git@main
+        pipx install git+https://github.com/python-poetry/poetry.git@main --python $(which python)
       shell: bash
     - if: ${{ inputs.poetry-version != 'latest' && inputs.poetry-version != 'main' }}
       run: |
-        pipx install poetry==${{ inputs.poetry-version }}
-      shell: bash
-    - run: |
-        pipx ensurepath
+        pipx install poetry==${{ inputs.poetry-version }} --python $(which python)
       shell: bash
     - if: ${{ inputs.poetry-plugins != '' }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ runs:
       run: |
         pipx install poetry==${{ inputs.poetry-version }}
       shell: bash
+    - run: |
+        pipx ensurepath
+      shell: bash
     - if: ${{ inputs.poetry-plugins != '' }}
       run: |
         ALL_PLUGINS=$(echo "${{ inputs.poetry-plugins }}")


### PR DESCRIPTION
Fixes: #85 
* #85

`pipx` is installing in the system Python instead of the user’s current `python`.