### PR TITLE
Changed plugins to rely on pipx + Added readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ jobs:
     poetry-version: "latest"
 
     # Specify additional packages with plugins for Poetry to install after installing Poetry itself.
+    # Specify a JSON array as string, e.g. "['plugin-1', 'plugin-2', 'plugin-3']".
     poetry-plugins: ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ jobs:
         run: poetry run pytest -v
 ```
 
+## Options
+
+```yaml
+- uses: ...
+  with:
+    # Version of Poetry to install (e.g. "v1.8.4"). Use "latest" to get the latest PyPi release, or 
+    # "main" to get the latest commit.
+    poetry-version: "latest"
+
+    # Specify additional packages with plugins for Poetry to install after installing Poetry itself.
+    poetry-plugins: ""
+```
+
 ## License
 
 [MIT License - abatilo/actions-poetry]

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,8 @@ runs:
       shell: bash
     - if: ${{ inputs.poetry-plugins != '' }}
       run: |
-        ALL_PLUGINS=$(echo "${{ inputs.poetry-plugins }}")
-        for PLUGIN in $ALL_PLUGINS; do
+        for PLUGIN in ${{ join(fromJSON(inputs.poetry-plugins), ' ') }}
+        do
           pipx inject poetry $PLUGIN
         done
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,6 @@ runs:
       run: |
         ALL_PLUGINS=$(echo "${{ inputs.poetry-plugins }}")
         for PLUGIN in $ALL_PLUGINS; do
-          poetry self add $PLUGIN
+          pipx inject poetry $PLUGIN
         done
       shell: bash


### PR DESCRIPTION
I think the pipx injection is more robust if we're already installing Poetry with pipx.

And I copied the documentation style for options from https://github.com/actions/checkout 

An example of usages: https://github.com/DEMCON/twincat-tools/actions/runs/13370258351 

Relates to
- #89 